### PR TITLE
feat: Expose a generic query to the templates

### DIFF
--- a/Sources/Builder.swift
+++ b/Sources/Builder.swift
@@ -115,18 +115,15 @@ class Builder {
                 "date_format_short": "MMMM dd",
                 "url": "https://jbmorley.co.uk",
                 "posts": Function { () throws -> [DocumentContext] in
-                    return try queryTracker.documents(query: QueryDescription())
-                        .map { DocumentContext(store: queryTracker, document: $0) }
-                },
-                "children": Function { (parent: String) throws -> [DocumentContext] in
-                    return try queryTracker.documents(query: QueryDescription(parent: parent))
-                        .map { DocumentContext(store: queryTracker, document: $0) }
+                    return try queryTracker.documentContexts(query: QueryDescription())
                 },
                 "post": Function { (url: String) throws -> DocumentContext? in
-                    return try queryTracker.documents(query: QueryDescription(url: url))
-                        .map { DocumentContext(store: queryTracker, document: $0) }
-                        .first
+                    return try queryTracker.documentContexts(query: QueryDescription(url: url)).first
                 },
+                "query": Function { (definition: [AnyHashable: Any]) throws -> [DocumentContext] in
+                    let query = try QueryDescription(definition: definition)
+                    return try queryTracker.documentContexts(query: query)
+                }
             ] as Dictionary<String, Any>,  // TODO: as [String: Any] is different?
             "generate_uuid": Function {
                 return UUID().uuidString

--- a/Sources/Store/QueryDescription.swift
+++ b/Sources/Store/QueryDescription.swift
@@ -80,15 +80,8 @@ struct QueryDescription: Codable, Hashable {
         } else {
             includeCategories = nil
         }
-        if let parent = structuredQuery["parent"] {
-            guard let parent = parent as? String else {
-                throw InContextError.invalidQueryDefinition
-            }
-            self.parent = parent
-        } else {
-            self.parent = nil
-        }
-        self.url = try structuredQuery.optionalValue(for: "parent")
+        self.parent = try structuredQuery.optionalValue(for: "parent")
+        self.url = try structuredQuery.optionalValue(for: "url")
         self.relativeSourcePath = try structuredQuery.optionalValue(for: "relative_source_path")
     }
 

--- a/Sources/Store/QueryTracker.swift
+++ b/Sources/Store/QueryTracker.swift
@@ -22,12 +22,12 @@
 
 import Foundation
 
-class QueryTracker: Queryable {
+class QueryTracker {
 
-    let store: Queryable
+    let store: Store
     var queries: [QueryStatus] = []
 
-    init(store: Queryable) {
+    init(store: Store) {
         self.store = store
     }
 
@@ -37,6 +37,11 @@ class QueryTracker: Queryable {
         queries.append(QueryStatus(query: query,
                                    contentModificationDates: documents.map({ $0.contentModificationDate })))
         return documents
+    }
+
+    func documentContexts(query: QueryDescription) throws -> [DocumentContext] {
+        return try documents(query: query)
+            .map { DocumentContext(store: self, document: $0) }
     }
 
 }

--- a/Sources/Store/Store.swift
+++ b/Sources/Store/Store.swift
@@ -24,7 +24,7 @@ import Foundation
 
 import SQLite
 
-class Store: Queryable {
+class Store {
 
     struct Schema {
 

--- a/Sources/Transforms/ImageDocumentTransform.swift
+++ b/Sources/Transforms/ImageDocumentTransform.swift
@@ -22,7 +22,6 @@
 
 import Foundation
 
-import Stencil
 import SwiftSoup
 
 // Corrects relative paths for images have been stored in the database.
@@ -32,7 +31,7 @@ import SwiftSoup
 // TODO: These transforms also need rigorous testing
 struct ImageDocumentTransform: Transformer {
 
-    func transform(store: Queryable, document: DocumentContext, content: SwiftSoup.Document) throws {
+    func transform(store: QueryTracker, document: DocumentContext, content: SwiftSoup.Document) throws {
         for img in try content.getElementsByTag("img") {
             if img.hasAttr("src") {
                 let src = try img.attr("src")

--- a/Sources/Transforms/RelativeSourceTransform.swift
+++ b/Sources/Transforms/RelativeSourceTransform.swift
@@ -22,8 +22,29 @@
 
 import Foundation
 
-protocol Queryable {
+import SwiftSoup
 
-    func documents(query: QueryDescription) throws -> [Document]
+struct RelativeSourceTransform: Transformer {
+
+    let selector: String
+    let attribute: String
+
+    func transform(store: QueryTracker, document: DocumentContext, content: SwiftSoup.Document) throws {
+        for element in try content.select(selector) {
+            guard element.hasAttr(attribute) else {
+                continue
+            }
+            let value = try element.attr(attribute)
+            // TODO: This should not make a change if path is a fully qualified URL.
+            guard !value.hasPrefix("/") else {
+                continue
+            }
+
+            let newValue = document.relativeSourcePath(for: value)
+            print("!!!!!!!")
+            print(newValue)
+            try element.attr(attribute, newValue)
+        }
+    }
 
 }

--- a/Sources/Transforms/Transformer.swift
+++ b/Sources/Transforms/Transformer.swift
@@ -26,6 +26,6 @@ import SwiftSoup
 
 protocol Transformer {
 
-    func transform(store: Queryable, document: DocumentContext, content: SwiftSoup.Document) throws
+    func transform(store: QueryTracker, document: DocumentContext, content: SwiftSoup.Document) throws
 
 }


### PR DESCRIPTION
This change also moves some of the document context construction into `QueryTracker` to avoid having to perform that at every call-site.