### PR TITLE
fix: Import image descriptions and locations

### DIFF
--- a/Sources/Contexts/DocumentContext.swift
+++ b/Sources/Contexts/DocumentContext.swift
@@ -127,6 +127,14 @@ struct DocumentContext: EvaluationContext, DynamicMemberLookup {
         case "parent": return Function { () -> DocumentContext? in
             return try store.documentContexts(query: QueryDescription(url: document.parent)).first
         }
+        case "previous": return Function { () -> DocumentContext? in
+            // TODO: Implement me!
+            return nil
+        }
+        case "next": return Function { () -> DocumentContext? in
+            // TODO: Implement me!
+            return nil
+        }
         case "child": return Function { (relativePath: String) -> DocumentContext? in
             let relativeSourcePath = relativeSourcePath(for: relativePath)
             return try store.documentContexts(query: QueryDescription(relativeSourcePath: relativeSourcePath)).first


### PR DESCRIPTION
This change also includes a drive-by fix to stub-out the `previous` and `next` page methods.