### PR TITLE
fix: Improve error reporting when calling context functions with incorrect arguments

### DIFF
--- a/Sources/Contexts/DocumentContext.swift
+++ b/Sources/Contexts/DocumentContext.swift
@@ -29,6 +29,19 @@ struct DocumentContext: EvaluationContext {
     private let renderTracker: RenderTracker  // TODO: Rename to rendertracker
     private let document: Document
 
+    var url: String {
+        return document.url
+    }
+
+    var title: String? {
+        return document.title
+    }
+
+    var format: Document.Format {
+        return document.format
+    }
+
+    // TODO: Rename to `text` to differentiate it from `html`
     var content: String {
         // TODO: Consistent content/contents naming.
         return document.contents
@@ -104,13 +117,23 @@ struct DocumentContext: EvaluationContext {
         return try content.html()
     }
 
-    // TODO: This shouldn't throw.
     func lookup(_ name: String) throws -> Any? {
         switch name {
+        case "url":
+            return url
         case "title":
-            return document.title
+            return title
         case "format":
-            return document.format.rawValue
+            return format.rawValue
+        case "content":
+            return content
+        case "html":
+            // TODO: Make this a method to make it apparent to the template that it's doing work.
+            return try html()
+        case "date":
+            return date
+        case "contentModificationDate", "last_modified":
+            return contentModificationDate
         case "query": return Function { (name: String) -> [DocumentContext] in
             guard let queries = document.metadata["queries"] as? [String: Any],
                   let query = queries[name] else {
@@ -165,27 +188,8 @@ struct DocumentContext: EvaluationContext {
             return relativeSourcePath.ensureLeadingSlash()
         }
         default:
-            break
+            return document.metadata[name]
         }
-        return self[dynamicMember: name]
-    }
-
-    subscript(dynamicMember member: String) -> Any? {
-        if member == "content" {
-            return document.contents
-        } else if member == "date" {
-            return date
-        } else if member == "contentModificationDate" {
-            return contentModificationDate
-        } else if member == "html" {
-            // TODO: Don't crash!
-            return try! html()
-        } else if member == "url" {
-            return document.url
-        } else if member == "last_modified" {
-            return contentModificationDate
-        }
-        return document.metadata[member]
     }
 
 }

--- a/Sources/Extensions/Dictionary.swift
+++ b/Sources/Extensions/Dictionary.swift
@@ -29,7 +29,7 @@ extension Dictionary {
             return defaultValue
         }
         guard let value = value as? T else {
-            throw InContextError.incorrectType(key)
+            throw InContextError.incorrectType(expected: T.Type.self, received: value)
         }
         return value
     }
@@ -52,7 +52,7 @@ extension Dictionary {
             return nil
         }
         guard let value = value as? T else {
-            throw InContextError.incorrectType(key)
+            throw InContextError.incorrectType(expected: T.Type.self, received: value)
         }
         return value
     }
@@ -62,7 +62,7 @@ extension Dictionary {
             throw InContextError.missingKey(key)
         }
         guard let value = value as? T else {
-            throw InContextError.incorrectType(key)
+            throw InContextError.incorrectType(expected: T.Type.self, received: value)
         }
         return value
     }
@@ -70,7 +70,7 @@ extension Dictionary {
     func requiredRawRepresentable<T: RawRepresentable>(for key: Key) throws -> T {
         let rawValue: T.RawValue = try requiredValue(for: key)
         guard let value = T(rawValue: rawValue) else {
-            throw InContextError.incorrectType(key)
+            throw InContextError.incorrectType(expected: T.Type.self, received: rawValue)
         }
         return value
     }
@@ -80,7 +80,7 @@ extension Dictionary {
             return nil
         }
         guard let value = T(rawValue: rawValue) else {
-            throw InContextError.incorrectType(key)
+            throw InContextError.incorrectType(expected: T.Type.self, received: rawValue)
         }
         return value
     }

--- a/Sources/InContextError.swift
+++ b/Sources/InContextError.swift
@@ -23,6 +23,7 @@
 import Foundation
 
 enum InContextError: Error {
+    
     case encodingError
     case internalInconsistency(String)
     case unknownSymbol(String)
@@ -37,12 +38,15 @@ enum InContextError: Error {
     case notFound
     case unknownQuery(String)
     case invalidQueryDefinition
-    case incorrectType(AnyHashable)
     case missingKey(Any)
     case interrupted
     case unknownTemplate(String)
     case importError(URL, Error)
 
+    // Function calls.
+    case incorrectType(expected: Any.Type, received: Any?)
+    case incorrectArguments
+    case noMatchingFunction
 }
 
 extension InContextError: LocalizedError {
@@ -55,6 +59,11 @@ extension InContextError: LocalizedError {
             return message
         case .importError(let fileURL, let error):
             return "Failed to import file '\(fileURL.relativePath)' with error '\(error.localizedDescription)'."
+        case .incorrectType(expected: let expected, received: let received):
+            guard let received else {
+                return "Incorrect type: expected '\(expected)', got nil."
+            }
+            return "Incorrect type: expected '\(expected)', got '\(received)' ('\(type(of: received))')."
         default:
             return String(describing: self)
         }

--- a/Sources/Utilities/Callable.swift
+++ b/Sources/Utilities/Callable.swift
@@ -22,14 +22,6 @@
 
 import Foundation
 
-enum CallableError: Error {
-
-    case incorrectArguments
-    case incorectType
-    case noMatchingFunction
-    
-}
-
 protocol Callable {
 
     func call(with provider: ArgumentProvider) throws -> Any?
@@ -43,13 +35,13 @@ extension Array: Callable where Element == Callable {
             for callable in self {
                 do {
                     return try callable.call(with: arguments)
-                } catch CallableError.incorrectArguments,
-                        CallableError.noMatchingFunction,
-                        CallableError.incorectType {
+                } catch InContextError.incorrectArguments,
+                        InContextError.noMatchingFunction,
+                        InContextError.incorrectType {
                     continue
                 }
             }
-            throw CallableError.noMatchingFunction
+            throw InContextError.noMatchingFunction
         }
     }
 

--- a/Sources/Utilities/Candidates.swift
+++ b/Sources/Utilities/Candidates.swift
@@ -35,15 +35,13 @@ class Candidates: Callable {
             for callable in self.callables {
                 do {
                     return try callable.call(with: arguments)
-                } catch CallableError.incorrectArguments {
-                    continue
-                } catch CallableError.noMatchingFunction {
-                    continue
-                } catch CallableError.incorectType {
+                } catch InContextError.incorrectArguments,
+                        InContextError.noMatchingFunction,
+                        InContextError.incorrectType {
                     continue
                 }
             }
-            throw CallableError.noMatchingFunction
+            throw InContextError.noMatchingFunction
         }
     }
 

--- a/Sources/Utilities/Function.swift
+++ b/Sources/Utilities/Function.swift
@@ -32,7 +32,7 @@ struct Function: EvaluationContext, Callable {
 
     static func checkLength<T>(_ array: [T], length: Int) throws {
         guard array.count == length else {
-            throw CallableError.incorrectArguments
+            throw InContextError.incorrectArguments
         }
     }
 
@@ -48,7 +48,7 @@ struct Function: EvaluationContext, Callable {
             // return a typed result.
             return converted as! T
         } else {
-            throw CallableError.incorectType
+            throw InContextError.incorrectType(expected: T.Type.self, received: value)
         }
     }
 


### PR DESCRIPTION
This change includes a drive-by refactor to clean up the `DocumentContext` symbol and function lookup.