### PR TITLE
fix: Expose (and use) render methods directly on `RenderTracker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ swift build
 
 - [ ] What is the performance hit of using a regex in the frontmatter parser?
 - [ ] Use the Swift `Regex` DSL
-- [ ] Support loading the existing stie configuration
+- [ ] Support loading the existing site configuration
 - [ ] Track resources and clean them up when files are deleted or importers change
 - [ ] Try using a multi-reader / single-writer model for the database to improve template render performance
 - [ ] Use Swift DSL to unify file and image handlers (this would allow easy checking of glob, regex, extension, and mime
@@ -49,9 +49,8 @@ swift build
   - [ ] STL
   - [ ] Audio
 - [ ] Add a --Werror flag
-- [ ] Consider using SQLite.swift custom type support (https://github.com/stephencelis/SQLite.swift/blob/master/Documentation/Index.md#custom-types)
 - [ ] Import image dates
 - [ ] Video documents aren't being loaded correctly
 - [ ] Figure out how to do per-item templates (inline templates)?
-- [ ] Better error reporting for incorrect types
 - [ ] Consider making thumbnail an explicit property on document types and moving user metadata into a substructure
+- [ ] Port legacy InContext 2 tests

--- a/Sources/Contexts/DocumentContext.swift
+++ b/Sources/Contexts/DocumentContext.swift
@@ -26,7 +26,7 @@ import SwiftSoup
 
 struct DocumentContext: EvaluationContext {
 
-    private let renderTracker: RenderTracker  // TODO: Rename to rendertracker
+    private let renderTracker: RenderTracker
     private let document: Document
 
     var url: String {

--- a/Sources/RenderTracker.swift
+++ b/Sources/RenderTracker.swift
@@ -62,4 +62,9 @@ class RenderTracker {
                             templates: Array(statuses))
     }
 
+    func render(template: TemplateIdentifier,
+                context: [String: Any]) async throws -> String {
+        return try await renderManager.render(renderTracker: self, template: template, context: context)
+    }
+
 }


### PR DESCRIPTION
We should be able to use these to track inline template renders when cleaning up the HTML.