### PR TITLE
fix: Support richer image transform rules

### DIFF
--- a/Sources/Command.swift
+++ b/Sources/Command.swift
@@ -45,8 +45,11 @@ struct Options: ParsableArguments {
             transform: URL.init(fileURLWithPath:))
     var site: URL?
 
-    @Flag(help: "run template renders concurrently")
-    var concurrentRenders = false
+    @Flag(help: "serialize import")
+    var serializeImport = false
+
+    @Flag(help: "serialize template render")
+    var serializeRender = false
 
     @Flag(help: "watch for changes to the content directory")
     var watch = false
@@ -78,7 +81,9 @@ extension Command {
 
         mutating func run() async throws {
             let site = try options.resolveSite()
-            let ic = try await Builder(site: site, concurrentRenders: options.concurrentRenders)
+            let ic = try await Builder(site: site,
+                                       serializeImport: options.serializeImport,
+                                       serializeRender: options.serializeRender)
             try await ic.build(watch: options.watch)
         }
 
@@ -106,7 +111,9 @@ extension Command {
                 return
             }
 
-            let ic = try await Builder(site: site, concurrentRenders: options.concurrentRenders)
+            let ic = try await Builder(site: site,
+                                       serializeImport: options.serializeImport,
+                                       serializeRender: options.serializeRender)
             try await ic.build(watch: options.watch)
         }
 

--- a/Sources/Extensions/String.swift
+++ b/Sources/Extensions/String.swift
@@ -26,6 +26,8 @@ import MarkdownKit
 
 extension String {
 
+    private static let schemeRegex = /[a-z]+:/.ignoresCase()
+
     func wrapped(by prefix: String, and suffix: String) -> String {
         return prefix + self + suffix
     }
@@ -34,6 +36,12 @@ extension String {
         let markdown = ExtendedMarkdownParser.standard.parse(self)
         let html = HtmlGenerator.standard.generate(doc: markdown)
         return html
+    }
+
+    var hasScheme: Bool {
+        get throws {
+            return try Self.schemeRegex.prefixMatch(in: self) != nil
+        }
     }
 
 }

--- a/Sources/Extensions/URL.swift
+++ b/Sources/Extensions/URL.swift
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import Foundation
+import UniformTypeIdentifiers
 
 import Titlecaser
 import RegexBuilder
@@ -88,6 +89,10 @@ extension URL {
     func basenameDetails() -> BasenameDetails {
         let (date, title, scale) = relevantBasename.splitBasenameComponents()
         return BasenameDetails(date: date, title: title.replacingOccurrences(of: "-", with: " ").toTitleCase(), scale: scale)
+    }
+
+    var type: UTType? {
+        return UTType(filenameExtension: pathExtension)
     }
 
 }

--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -27,34 +27,6 @@ import Yaml
 
 struct Site {
 
-    // TODO: Replicate the InContext 2 transforms:
-    //profiles:
-    //
-    //    default:
-    //
-    //      - where: metadata(projection="equirectangular")
-    //        transforms:
-    //          - resize("large", width=10000, sets=["image"])
-    //          - fisheye("preview-small", width=480, format="image/png", sets=["thumbnail", "previews"])
-    //          - fisheye("preview-large", width=960, format="image/png", sets=["previews"])
-    //
-    //      - where: glob("*.heic") or glob("*.tiff")
-    //        transforms:
-    //          - resize("large", width=1600, format="image/jpeg", sets=["image", "previews"])
-    //          - resize("small", width=480, format="image/jpeg", sets=["thumbnail", "previews"])
-    //
-    //      - where: glob("*")
-    //        transforms:
-    //          - resize("large", width=1600, sets=["image", "previews"])
-    //          - resize("small", width=480, sets=["thumbnail", "previews"])
-
-    // TODO: These are hardcoded as resize operations; they should have custom names and be able to apply 'filters'.
-    // TODO: Need to be able to always clamp to specific dimension.
-    let transforms = [
-        ImageTransform(basename: "large", width: 1600, format: .jpeg, sets: ["image", "previews"]),
-        ImageTransform(basename: "small", width: 480, format: .jpeg, sets: ["thumbnail", "previews"]),
-    ]
-
     let rootURL: URL
     let contentURL: URL
     let templatesURL: URL

--- a/Sources/Transforms/ImageDocumentTransform.swift
+++ b/Sources/Transforms/ImageDocumentTransform.swift
@@ -36,6 +36,7 @@ struct ImageDocumentTransform: Transformer {
         for img in try content.getElementsByTag("img") {
             if img.hasAttr("src") {
                 let src = try img.attr("src")
+
                 let query = QueryDescription(relativeSourcePath: document.relativeSourcePath(for: src))
                 guard let document = try renderTracker.documents(query: query).first else {
                     print("Failed to update src for '\(src)'.")


### PR DESCRIPTION
This change updates the hard-coded rule set to honour input formats for everything except TIFF and HEIC which are always transformed to JPEG.