### PR TITLE
fix: Always generate thumbnails instead of using file metadata

### DIFF
--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -9,9 +9,10 @@ ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
 
 pushd "$ROOT_DIRECTORY"
 swift build -c release
-BINARY_DIRECTORY=`swift build --product incontext --show-bin-path`
+BINARY_DIRECTORY=`swift build -c release --product incontext --show-bin-path`
 BINARY_DIRECTORY="$( cd "$BINARY_DIRECTORY" &> /dev/null &&
 pwd )"
 popd
 
+echo "Running '$BINARY_DIRECTORY'..."
 "$BINARY_DIRECTORY/incontext" $@


### PR DESCRIPTION
This addresses a bug where image scales were too small.