### PR TITLE
fix: Include the optional image projection in the document metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ These changes impact the rendering of jbmorley.co.uk and block switching to InCo
 7. **Check that the JSON feed works**
 8. Pass-through site metadata so that things like tags can be rendered correctly
 9. Check that gifs are transformed correctly
-10. 360 photos aren't processed correctly
+10. 360 degree viewer isn't used
 11. Migrate EXIF sidecars
 12. The vertical spacing seems off on jbmorley.co.uk (this is probably a legacy stylesheet issue)
 13. Markdown issues
@@ -112,6 +112,7 @@ These changes impact the rendering of jbmorley.co.uk and block switching to InCo
 15. Preserve image and video alt-text when transforming markdown media
 16. Timezone handling is currently inconsistent and unclear
 17. Render caching currently means that it's not possible to use incremental builds for deployments
+18. 360 degree mini worlds aren't generated
 
 ### Background
 

--- a/Sources/Contexts/DocumentContext.swift
+++ b/Sources/Contexts/DocumentContext.swift
@@ -229,6 +229,11 @@ struct DocumentContext: EvaluationContext {
             //       (or doesn't exist in the site).
             // TODO: This is currently guess-work and should be far more rigorously coded with updates to Document in
             //       the future.
+
+            if relativePath == "." {
+                return url
+            }
+
             let relativeSourcePath = relativeSourcePath(for: relativePath)
 
             // We currently special-case image documents that follow a known structure.
@@ -238,7 +243,7 @@ struct DocumentContext: EvaluationContext {
                 return url
             }
             
-            return relativeSourcePath.ensuringLeadingSlash()
+            return relativeSourcePath.ensuringLeadingSlash().ensuringTrailingSlash()
         }
         default:
             return document.metadata[name]

--- a/Sources/Importers/ImageImporter.swift
+++ b/Sources/Importers/ImageImporter.swift
@@ -324,7 +324,7 @@ class ImageImporter: Importer {
         }
 
         guard let exif = try EXIF(image, 0) else {
-            throw InContextError.internalInconsistency("Failed to load metadata for image at '\(fileURL.relativePath)'.")
+            throw InContextError.internalInconsistency("Failed to load properties for image at '\(fileURL.relativePath)'.")
         }
 
         let details = fileURL.basenameDetails()
@@ -334,6 +334,10 @@ class ImageImporter: Importer {
 
         if let scale = details.scale {
             metadata["scale"] = scale
+        }
+
+        if let projectionType = try exif.projectionType {
+            metadata["projection"] = projectionType
         }
 
         // Content.


### PR DESCRIPTION
This change also includes a small fix to the `resolve` context function to support resolving '.'.