### PR TITLE
fix: Use document content fingerprints to track render changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Templates are written in [Tilt](https://github.com/tomsci/tomscis-lua-templater)
 These changes impact the rendering of jbmorley.co.uk and block switching to InContext 3.
 
 1. **Deleted documents aren't removed from the store**
-2. **Incremental builds don't notice settings changes**
 3. **Check adaptive images work**
 4. **Don't automatically replace non-Markdown image tags**
 5. **Videos** (Location, Titles)

--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -43,4 +43,78 @@ struct Document {
     let relativeSourcePath: String
     let format: Format
 
+    let fingerprint: String
+
+    init(url: String,
+         parent: String,
+         category: String,
+         date: Date?,
+         title: String?,
+         metadata: [AnyHashable: Any],
+         contents: String,
+         contentModificationDate: Date,
+         template: TemplateIdentifier,
+         inlineTemplate: TemplateIdentifier?,
+         relativeSourcePath: String,
+         format: Format,
+         fingerprint: String) {
+        self.url = url
+        self.parent = parent
+        self.category = category
+        self.date = date
+        self.title = title
+        self.metadata = metadata
+        self.contents = contents
+        self.contentModificationDate = contentModificationDate
+        self.template = template
+        self.inlineTemplate = inlineTemplate
+        self.relativeSourcePath = relativeSourcePath
+        self.format = format
+        self.fingerprint = fingerprint
+    }
+
+    init(url: String,
+         parent: String,
+         category: String,
+         date: Date?,
+         title: String?,
+         metadata: [AnyHashable: Any],
+         contents: String,
+         contentModificationDate: Date,
+         template: TemplateIdentifier,
+         inlineTemplate: TemplateIdentifier?,
+         relativeSourcePath: String,
+         format: Format) throws {
+        self.url = url
+        self.parent = parent
+        self.category = category
+        self.date = date
+        self.title = title
+        self.metadata = metadata
+        self.contents = contents
+        self.contentModificationDate = contentModificationDate
+        self.template = template
+        self.inlineTemplate = inlineTemplate
+        self.relativeSourcePath = relativeSourcePath
+        self.format = format
+
+        var fingerprint = Fingerprint()
+        try fingerprint.update(url)
+        try fingerprint.update(category)
+        if let date {
+            try fingerprint.update(date)
+        }
+        if let title {
+            try fingerprint.update(title)
+        }
+        try fingerprint.update(metadata)
+        try fingerprint.update(contents)
+        try fingerprint.update(contentModificationDate)
+        try fingerprint.update(template)
+        if let inlineTemplate {
+            try fingerprint.update(inlineTemplate)
+        }
+        self.fingerprint = fingerprint.finalize()
+    }
+
 }

--- a/Sources/Extensions/Array.swift
+++ b/Sources/Extensions/Array.swift
@@ -72,3 +72,14 @@ extension Array {
     }
 
 }
+
+extension Array: Fingerprintable {
+
+    func combine(into fingerprint: inout Fingerprint) throws {
+        let items: [any Fingerprintable] = try cast(self)
+        for item in items {
+            try fingerprint.update(item)
+        }
+    }
+
+}

--- a/Sources/Extensions/Bool.swift
+++ b/Sources/Extensions/Bool.swift
@@ -22,9 +22,10 @@
 
 import Foundation
 
-struct QueryStatus: Codable, Hashable {
+extension Bool: Fingerprintable {
 
-    let query: QueryDescription
-    let fingerprints: [String]
+    func combine(into fingerprint: inout Fingerprint) throws {
+        try fingerprint.update(self)
+    }
 
 }

--- a/Sources/Extensions/Dictionary.swift
+++ b/Sources/Extensions/Dictionary.swift
@@ -115,3 +115,20 @@ extension Dictionary: EvaluationContext where Key == AnyHashable, Value == Any {
     }
 
 }
+
+extension Dictionary: Fingerprintable {
+
+    func combine(into fingerprint: inout Fingerprint) throws {
+        // In order to come up with a stable fingerprint, we need to guarantee that we combine our keys-value pairs in
+        // a predictable order. We therefore limit this to a dictionary with string keys.
+        let contents: [String: Any] = try cast(self)
+        let keys = contents.keys.sorted()
+        for key in keys {
+            let value: any Fingerprintable = try cast(contents[key]!)
+            try fingerprint.update(key)
+            try fingerprint.update(value)
+        }
+
+    }
+
+}

--- a/Sources/Extensions/Double.swift
+++ b/Sources/Extensions/Double.swift
@@ -22,9 +22,10 @@
 
 import Foundation
 
-struct QueryStatus: Codable, Hashable {
+extension Double: Fingerprintable {
 
-    let query: QueryDescription
-    let fingerprints: [String]
+    func combine(into fingerprint: inout Fingerprint) throws {
+        try fingerprint.update(self)
+    }
 
 }

--- a/Sources/Extensions/Float.swift
+++ b/Sources/Extensions/Float.swift
@@ -22,9 +22,10 @@
 
 import Foundation
 
-struct QueryStatus: Codable, Hashable {
+extension Float: Fingerprintable {
 
-    let query: QueryDescription
-    let fingerprints: [String]
+    func combine(into fingerprint: inout Fingerprint) throws {
+        try fingerprint.update(self)
+    }
 
 }

--- a/Sources/Extensions/Int.swift
+++ b/Sources/Extensions/Int.swift
@@ -22,9 +22,10 @@
 
 import Foundation
 
-struct QueryStatus: Codable, Hashable {
+extension Int: Fingerprintable {
 
-    let query: QueryDescription
-    let fingerprints: [String]
+    func combine(into fingerprint: inout Fingerprint) throws {
+        try fingerprint.update(self)
+    }
 
 }

--- a/Sources/Extensions/String.swift
+++ b/Sources/Extensions/String.swift
@@ -60,3 +60,11 @@ extension String {
     }
 
 }
+
+extension String: Fingerprintable {
+
+    func combine(into fingerprint: inout Fingerprint) throws {
+        try fingerprint.update(self)
+    }
+
+}

--- a/Sources/Importers/CopyImporter.swift
+++ b/Sources/Importers/CopyImporter.swift
@@ -26,7 +26,7 @@ class CopyImporter: Importer {
 
     typealias Settings = EmptySettings
 
-    let identifier = "copy_file"
+    let identifier = "copy"
     let version = 1
 
     func settings(for configuration: [String : Any]) throws -> EmptySettings {

--- a/Sources/Importers/ImageImporter.swift
+++ b/Sources/Importers/ImageImporter.swift
@@ -381,19 +381,23 @@ class ImageImporter: Importer {
         let filenameTitle = settings.titleFromFilename ? details.title : nil
 
         // N.B. The EXIF 'DateTimeOriginal' field sometimes appears to be invalid so we fall back on DateTimeDigitized.
-        let document = Document(url: fileURL.siteURL,
-                                parent: fileURL.parentURL,
-                                category: settings.defaultCategory,
-                                date: try (try? exif.dateTimeOriginal) ?? (try exif.dateTimeDigitized) ?? details.date,
-                                title: try exif.firstTitle ?? content?.structuredMetadata.title ?? filenameTitle,
-                                metadata: context.metadata,
-                                contents: content?.content ?? "",
-                                contentModificationDate: file.contentModificationDate,
-                                template: settings.defaultTemplate,
-                                inlineTemplate: settings.inlineTemplate,
-                                relativeSourcePath: file.relativePath,
-                                format: .image)
-        return ImporterResult(documents: [document], assets: context.assets)
+
+        let date = try (try? exif.dateTimeOriginal) ?? (try exif.dateTimeDigitized) ?? details.date
+        let title = try exif.firstTitle ?? content?.structuredMetadata.title ?? filenameTitle
+
+        let document = try Document(url: fileURL.siteURL,
+                                    parent: fileURL.parentURL,
+                                    category: settings.defaultCategory,
+                                    date: date,
+                                    title: title,
+                                    metadata: context.metadata,
+                                    contents: content?.content ?? "",
+                                    contentModificationDate: file.contentModificationDate,
+                                    template: settings.defaultTemplate,
+                                    inlineTemplate: settings.inlineTemplate,
+                                    relativeSourcePath: file.relativePath,
+                                    format: .image)
+        return ImporterResult(document: document, assets: context.assets)
     }
 
 }

--- a/Sources/Importers/Importer.swift
+++ b/Sources/Importers/Importer.swift
@@ -22,14 +22,13 @@
 
 import Foundation
 
-// TODO: Importers currently only generate one document.
 struct ImporterResult {
 
-    let documents: [Document]
+    let document: Document?
     let assets: [Asset]
 
-    init(documents: [Document] = [], assets: [Asset] = []) {
-        self.documents = documents
+    init(document: Document? = nil, assets: [Asset] = []) {
+        self.document = document
         self.assets = assets
     }
 

--- a/Sources/Importers/MarkdownImporter.swift
+++ b/Sources/Importers/MarkdownImporter.swift
@@ -58,19 +58,19 @@ class MarkdownImporter: Importer {
 
         let category: String = try metadata.value(for: "category", default: settings.defaultCategory)
 
-        let document = Document(url: fileURL.siteURL,
-                                parent: fileURL.parentURL,
-                                category: category,
-                                date: frontmatter.structuredMetadata.date ?? details.date,
-                                title: frontmatter.structuredMetadata.title ?? details.title,
-                                metadata: metadata,
-                                contents: frontmatter.content,
-                                contentModificationDate: file.contentModificationDate,
-                                template: frontmatter.structuredMetadata.template ?? settings.defaultTemplate,
-                                inlineTemplate: nil,
-                                relativeSourcePath: file.relativePath,
-                                format: .text)
-        return ImporterResult(documents: [document])
+        let document = try Document(url: fileURL.siteURL,
+                                    parent: fileURL.parentURL,
+                                    category: category,
+                                    date: frontmatter.structuredMetadata.date ?? details.date,
+                                    title: frontmatter.structuredMetadata.title ?? details.title,
+                                    metadata: metadata,
+                                    contents: frontmatter.content,
+                                    contentModificationDate: file.contentModificationDate,
+                                    template: frontmatter.structuredMetadata.template ?? settings.defaultTemplate,
+                                    inlineTemplate: nil,
+                                    relativeSourcePath: file.relativePath,
+                                    format: .text)
+        return ImporterResult(document: document)
     }
 
 }

--- a/Sources/Importers/VideoImporter.swift
+++ b/Sources/Importers/VideoImporter.swift
@@ -139,20 +139,20 @@ class VideoImporter: Importer {
             "video": videoDetails,
         ]
 
-        let document = Document(url: fileURL.siteURL,
-                                parent: fileURL.parentURL,
-                                category: settings.defaultCategory,
-                                date: content?.structuredMetadata.date ?? date,
-                                title: content?.structuredMetadata.title,  // TODO: Title
-                                metadata: metadata,
-                                contents: content?.content ?? "",
-                                contentModificationDate: file.contentModificationDate,
-                                template: settings.defaultTemplate,
-                                inlineTemplate: settings.inlineTemplate,
-                                relativeSourcePath: file.relativePath,
-                                format: .video)
+        let document = try Document(url: fileURL.siteURL,
+                                    parent: fileURL.parentURL,
+                                    category: settings.defaultCategory,
+                                    date: content?.structuredMetadata.date ?? date,
+                                    title: content?.structuredMetadata.title,  // TODO: Title
+                                    metadata: metadata,
+                                    contents: content?.content ?? "",
+                                    contentModificationDate: file.contentModificationDate,
+                                    template: settings.defaultTemplate,
+                                    inlineTemplate: settings.inlineTemplate,
+                                    relativeSourcePath: file.relativePath,
+                                    format: .video)
 
-        return ImporterResult(documents: [document], assets: [Asset(fileURL: videoURL), Asset(fileURL: thumbnailURL)])
+        return ImporterResult(document: document, assets: [Asset(fileURL: videoURL), Asset(fileURL: thumbnailURL)])
     }
 
     func thumbnail(asset: AVAsset, destinationURL: URL) async throws {

--- a/Sources/RenderStatus.swift
+++ b/Sources/RenderStatus.swift
@@ -22,14 +22,9 @@
 
 import Foundation
 
-// TODO: This should include the document fingerprint; or should it? I need to figure out how this gets replaced and
-//       add some unit tests accordingly.
-// TODO: We should version each renderer to allow us to push out bug fixes in the renderers.
 struct RenderStatus: Codable {
 
-    // TODO: This isn't the template modification date. It _is_ the document contentModificationDate.
-    //       It should be replaced with the document fingerprint.
-    let contentModificationDate: Date
+    let documentFingerprint: String
     let queries: [QueryStatus]
     let renderers: [RendererInstance]
     let templates: [TemplateRenderStatus]

--- a/Sources/RenderTracker.swift
+++ b/Sources/RenderTracker.swift
@@ -46,7 +46,7 @@ class RenderTracker {
     func documents(query: QueryDescription) throws -> [Document] {
         let documents = try store.documents(query: query)
         queries.insert(QueryStatus(query: query,
-                                   contentModificationDates: documents.map({ $0.contentModificationDate })))
+                                   fingerprints: documents.map({ $0.fingerprint })))
         return documents
     }
 
@@ -56,7 +56,7 @@ class RenderTracker {
     }
 
     func renderStatus(for document: Document) -> RenderStatus {
-        return RenderStatus(contentModificationDate: document.contentModificationDate,
+        return RenderStatus(documentFingerprint: document.fingerprint,
                             queries: Array(queries),
                             renderers: Array(renderers),
                             templates: Array(statuses))

--- a/Sources/Utilities/Fingerprint.swift
+++ b/Sources/Utilities/Fingerprint.swift
@@ -1,0 +1,95 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import Crypto
+
+struct Fingerprint {
+
+    public enum CryptoError: Error {
+        case encodingError
+    }
+
+    private var md5: Insecure.MD5
+
+    init() {
+        md5 = Insecure.MD5()
+    }
+
+    mutating func update(bufferPointer: UnsafeRawBufferPointer) {
+        md5.update(bufferPointer: bufferPointer)
+    }
+
+    mutating func update(_ fingerprintable: Fingerprintable) throws {
+        try fingerprintable.combine(into: &self)
+    }
+
+    mutating func update(_ int: Int) throws {
+        var int = int
+        withUnsafeBytes(of: &int) { data in
+            self.update(bufferPointer: data)
+        }
+    }
+
+    mutating func update(_ float: Float) throws {
+        var float = float
+        withUnsafeBytes(of: &float) { data in
+            self.update(bufferPointer: data)
+        }
+    }
+
+    mutating func update(_ double: Double) throws {
+        var double = double
+        withUnsafeBytes(of: &double) { data in
+            self.update(bufferPointer: data)
+        }
+    }
+
+    mutating func update(_ bool: Bool) throws {
+        var bool = bool
+        withUnsafeBytes(of: &bool) { data in
+            self.update(bufferPointer: data)
+        }
+    }
+
+    mutating func update(_ string: String) throws {
+        guard let data = string.data(using: .utf8) else {
+            throw CryptoError.encodingError
+        }
+        md5.update(data: data)
+    }
+
+    mutating func update(_ date: Date) throws {
+        var date = date.timeIntervalSinceReferenceDate
+        withUnsafeBytes(of: &date) { data in
+            self.update(bufferPointer: data)
+        }
+    }
+
+    func finalize() -> String {
+        let digest = md5.finalize()
+        let data = Data(digest)
+        return data.base64EncodedString()
+    }
+
+}

--- a/Sources/Utilities/Fingerprintable.swift
+++ b/Sources/Utilities/Fingerprintable.swift
@@ -22,8 +22,6 @@
 
 import Foundation
 
-import Crypto
-
 protocol Fingerprintable {
 
     func combine(into fingerprint: inout Fingerprint) throws
@@ -36,62 +34,6 @@ extension Fingerprintable {
         var fingerprint = Fingerprint()
         try combine(into: &fingerprint)
         return fingerprint.finalize()
-    }
-
-}
-
-struct Fingerprint {
-
-    public enum CryptoError: Error {
-        case encodingError
-    }
-
-    var md5: Insecure.MD5
-
-    init() {
-        md5 = Insecure.MD5()
-    }
-
-    mutating func update(bufferPointer: UnsafeRawBufferPointer) {
-        md5.update(bufferPointer: bufferPointer)
-    }
-
-    mutating func update(_ fingerprintable: Fingerprintable) throws {
-        try fingerprintable.combine(into: &self)
-    }
-
-    mutating func update(_ int: Int) throws {
-        var int = int
-        withUnsafeBytes(of: &int) { data in
-            self.update(bufferPointer: data)
-        }
-    }
-
-    mutating func update(_ bool: Bool) throws {
-        var bool = bool
-        withUnsafeBytes(of: &bool) { data in
-            self.update(bufferPointer: data)
-        }
-    }
-
-    mutating func update(_ string: String) throws {
-        guard let data = string.data(using: .utf8) else {
-            throw CryptoError.encodingError
-        }
-        md5.update(data: data)
-    }
-
-    mutating func update(_ date: Date) throws {
-        var date = date.timeIntervalSinceReferenceDate
-        withUnsafeBytes(of: &date) { data in
-            self.update(bufferPointer: data)
-        }
-    }
-
-    fileprivate func finalize() -> String {
-        let digest = md5.finalize()
-        let data = Data(digest)
-        return data.base64EncodedString()
     }
 
 }

--- a/Tests/ic3tests/Tests/ImageImporterTests.swift
+++ b/Tests/ic3tests/Tests/ImageImporterTests.swift
@@ -56,8 +56,8 @@ build_steps:
                                                defaultTemplate: TemplateIdentifier("photo.html"),
                                                inlineTemplate: TemplateIdentifier("image.html"))
         let result = try await importer.process(site: defaultSourceDirectory.site, file: file, settings: settings)
-        XCTAssertEqual(result.documents.count, 1)
-        XCTAssertEqual(result.documents.first?.title, "Hallgrímskirkja Church")
+        XCTAssertNotNil(result.document)
+        XCTAssertEqual(result.document?.title, "Hallgrímskirkja Church")
     }
 
 }

--- a/Tests/ic3tests/Tests/MarkdownImporterTests.swift
+++ b/Tests/ic3tests/Tests/MarkdownImporterTests.swift
@@ -53,8 +53,8 @@ These are the contents of the file.
                                                 file: file,
                                                 settings: .init(defaultCategory: "general",
                                                                 defaultTemplate: TemplateIdentifier("posts.html")))
-        XCTAssertEqual(result.documents.count, 1)
-        XCTAssertEqual(result.documents.first!.metadata["title"] as? String, "Fromage")
+        XCTAssertNotNil(result.document)
+        XCTAssertEqual(result.document!.metadata["title"] as? String, "Fromage")
     }
 
     func testMarkdownTitleFromFile() async throws {
@@ -77,8 +77,8 @@ build_steps:
                                                 file: file,
                                                 settings: .init(defaultCategory: "general",
                                                                 defaultTemplate: TemplateIdentifier("posts.html")))
-        XCTAssertEqual(result.documents.count, 1)
-        XCTAssertEqual(result.documents.first!.metadata["title"] as? String, "Cheese")
+        XCTAssertNotNil(result.document)
+        XCTAssertEqual(result.document!.metadata["title"] as? String, "Cheese")
     }
 
 }


### PR DESCRIPTION
This fixes a significant issue where per-import settings changes did not trigger a re-render.