### PR TITLE
fix: Support line separator as an alternative to new lines in Frontmatter

### DIFF
--- a/Sources/AnyHandler.swift
+++ b/Sources/AnyHandler.swift
@@ -26,7 +26,7 @@ struct AnyHandler {
 
     let _fingerprint: () throws -> String
     let _identifier: () -> String
-    let _process: (Site, File) async throws -> ImporterResult
+    let _process: (File, URL) async throws -> ImporterResult
     let _matches: (String) throws -> Bool
 
     func fingerprint() throws -> String {
@@ -44,8 +44,8 @@ struct AnyHandler {
         _identifier = {
             return handler.identifier
         }
-        _process = { site, file in
-            return try await handler.process(site: site, file: file)
+        _process = { file, outputURL in
+            return try await handler.process(file: file, outputURL: outputURL)
         }
         _matches = { path in
             return try handler.matches(relativePath: path)
@@ -56,8 +56,8 @@ struct AnyHandler {
         return try _matches(relativePath)
     }
 
-    func process(site: Site, file: File) async throws -> ImporterResult {
-        return try await _process(site, file)
+    func process(file: File, outputURL: URL) async throws -> ImporterResult {
+        return try await _process(file, outputURL)
     }
 
 }

--- a/Sources/Builder.swift
+++ b/Sources/Builder.swift
@@ -266,7 +266,7 @@ class Builder {
                     // Import the file.
                     let file = File(url: fileURL, contentModificationDate: contentModificationDate)
                     do {
-                        let result = try await handler.process(site: self.site, file: file)
+                        let result = try await handler.process(file: file, outputURL: self.site.filesURL)
                         let status = Status(fileURL: file.url,
                                             contentModificationDate: file.contentModificationDate,
                                             importer: handler.identifier,

--- a/Sources/FrontmatterDocument.swift
+++ b/Sources/FrontmatterDocument.swift
@@ -35,6 +35,11 @@ struct FrontmatterDocument {
     let content: String
 
     init(contents: String, generateHTML: Bool = false) throws {
+
+        // Sometimes we see 'line separator' characters (Unicode 2028) in image and video descriptions (thanks Photos),
+        // so we blanket replace these with new lines to be more forgiving.
+        let contents = contents.replacingOccurrences(of: "\u{2028}", with: "\n")
+
         guard let match = contents.wholeMatch(of: Self.frontmatterRegEx) else {
             rawMetadata = ""
             structuredMetadata = Metadata()

--- a/Sources/Handler.swift
+++ b/Sources/Handler.swift
@@ -62,8 +62,8 @@ extension Handler: Fingerprintable {
         return try when.wholeMatch(in: relativePath) != nil
     }
 
-    func process(site: Site, file: File) async throws -> ImporterResult {
-        return try await importer.process(site: site, file: file, settings: settings)
+    func process(file: File, outputURL: URL) async throws -> ImporterResult {
+        return try await importer.process(file: file, settings: settings, outputURL: outputURL)
     }
 
 }

--- a/Sources/Importers/CopyImporter.swift
+++ b/Sources/Importers/CopyImporter.swift
@@ -36,12 +36,14 @@ class CopyImporter: Importer {
         return EmptySettings()
     }
 
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult {
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult {
         // TODO: Consider whether these actually get a tracking context that lets them add to the site instead of
         //       returning documents. That feels like it might be cleaner and more flexible?
         //       That approach would have the benefit of meaning that we don't really need to do significant path
         //       manipulation.
-        let destinationURL = URL(filePath: file.relativePath, relativeTo: site.filesURL)
+        let destinationURL = URL(filePath: file.relativePath, relativeTo: outputURL)
         let fileManager = FileManager.default
         try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(),
                                         withIntermediateDirectories: true)

--- a/Sources/Importers/IgnoreImporter.swift
+++ b/Sources/Importers/IgnoreImporter.swift
@@ -36,7 +36,9 @@ class IgnoreImporter: Importer {
         return EmptySettings()
     }
 
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult {
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult {
         return ImporterResult()
     }
 

--- a/Sources/Importers/ImageImporter.swift
+++ b/Sources/Importers/ImageImporter.swift
@@ -310,12 +310,14 @@ class ImageImporter: Importer {
                         inlineTemplate: try args.requiredRawRepresentable(for: "inline_template"))
     }
 
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult {
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult {
 
         let fileURL = file.url
 
         // Create the assets directory.
-        let assetsURL = URL(filePath: fileURL.relevantRelativePath, relativeTo: site.filesURL)  // TODO: Make this a utiltiy and test it
+        let assetsURL = URL(filePath: fileURL.relevantRelativePath, relativeTo: outputURL)  // TODO: Make this a utiltiy and test it
         try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
 
         // Load the original image.

--- a/Sources/Importers/Importer.swift
+++ b/Sources/Importers/Importer.swift
@@ -46,7 +46,9 @@ protocol Importer {
     var version: Int { get }
 
     func settings(for configuration: [String: Any]) throws -> Settings
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult
 
 }
 

--- a/Sources/Importers/MarkdownImporter.swift
+++ b/Sources/Importers/MarkdownImporter.swift
@@ -45,7 +45,9 @@ class MarkdownImporter: Importer {
                         defaultTemplate: try args.requiredRawRepresentable(for: "default_template"))
     }
 
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult {
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult {
 
         let fileURL = file.url
         let details = fileURL.basenameDetails()

--- a/Sources/Importers/VideoImporter.swift
+++ b/Sources/Importers/VideoImporter.swift
@@ -50,12 +50,14 @@ class VideoImporter: Importer {
                         inlineTemplate: try args.requiredRawRepresentable(for: "inline_template"))
     }
 
-    func process(site: Site, file: File, settings: Settings) async throws -> ImporterResult {
+    func process(file: File,
+                 settings: Settings,
+                 outputURL: URL) async throws -> ImporterResult {
 
         let fileURL = file.url
 
         // Create the assets directory.
-        let assetsURL = URL(filePath: fileURL.relevantRelativePath, relativeTo: site.filesURL)
+        let assetsURL = URL(filePath: fileURL.relevantRelativePath, relativeTo: outputURL)
         try FileManager.default.createDirectory(at: assetsURL, withIntermediateDirectories: true)
 
         let asset = AVAsset(url: file.url)

--- a/Tests/ic3tests/Extensions/Utilities.swift
+++ b/Tests/ic3tests/Extensions/Utilities.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-func withTemporaryDirectory(perform: @escaping (URL) async throws -> Void) async throws {
+func withTemporaryDirectory(perform: /* @escaping */ (URL) async throws -> Void) async throws {
     let fileManager = FileManager.default
     let url = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     try fileManager.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Tests/ic3tests/Resources/2022-05-31-17-55-03-royal-wave.mov
+++ b/Tests/ic3tests/Resources/2022-05-31-17-55-03-royal-wave.mov
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10fd275433469ed94491d94abdc3690e5e5d96ee653a99f95c42a3db09089201
+size 10835051

--- a/Tests/ic3tests/Tests/ImageImporterTests.swift
+++ b/Tests/ic3tests/Tests/ImageImporterTests.swift
@@ -55,7 +55,9 @@ build_steps:
                                                titleFromFilename: false,
                                                defaultTemplate: TemplateIdentifier("photo.html"),
                                                inlineTemplate: TemplateIdentifier("image.html"))
-        let result = try await importer.process(site: defaultSourceDirectory.site, file: file, settings: settings)
+        let result = try await importer.process(file: file,
+                                                settings: settings,
+                                                outputURL: defaultSourceDirectory.site.filesURL)
         XCTAssertNotNil(result.document)
         XCTAssertEqual(result.document?.title, "Hallgrímskirkja Church")
     }

--- a/Tests/ic3tests/Tests/MarkdownImporterTests.swift
+++ b/Tests/ic3tests/Tests/MarkdownImporterTests.swift
@@ -49,10 +49,10 @@ title: Fromage
 These are the contents of the file.
 """)
         let importer = MarkdownImporter()
-        let result = try await importer.process(site: defaultSourceDirectory.site,
-                                                file: file,
+        let result = try await importer.process(file: file,
                                                 settings: .init(defaultCategory: "general",
-                                                                defaultTemplate: TemplateIdentifier("posts.html")))
+                                                                defaultTemplate: TemplateIdentifier("posts.html")),
+                                                outputURL: defaultSourceDirectory.site.filesURL)
         XCTAssertNotNil(result.document)
         XCTAssertEqual(result.document!.metadata["title"] as? String, "Fromage")
     }
@@ -73,10 +73,10 @@ build_steps:
 """)
         let file = try defaultSourceDirectory.add("cheese/index.markdown", location: .content, contents: "Contents!")
         let importer = MarkdownImporter()
-        let result = try await importer.process(site: defaultSourceDirectory.site,
-                                                file: file,
+        let result = try await importer.process(file: file,
                                                 settings: .init(defaultCategory: "general",
-                                                                defaultTemplate: TemplateIdentifier("posts.html")))
+                                                                defaultTemplate: TemplateIdentifier("posts.html")),
+                                                outputURL: defaultSourceDirectory.site.filesURL)
         XCTAssertNotNil(result.document)
         XCTAssertEqual(result.document!.metadata["title"] as? String, "Cheese")
     }

--- a/Tests/ic3tests/Tests/VideoImporterTests.swift
+++ b/Tests/ic3tests/Tests/VideoImporterTests.swift
@@ -1,0 +1,65 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+import XCTest
+@testable import incontext
+
+class VideoImporterTests: ContentTestCase {
+
+    func testExtractTitle() async throws {
+
+        try await withTemporaryDirectory { temporaryDirectoryURL in
+
+            let videoURL = try self.bundle.throwingURL(forResource: "2022-05-31-17-55-03-royal-wave",
+                                                       withExtension: "mov")
+            let video = try File(url: videoURL)
+
+            let importer = VideoImporter()
+            let result = try await importer.process(file: video,
+                                                    settings: VideoImporter.Settings(defaultCategory: "snapshots",
+                                                                                     titleFromFilename: false,
+                                                                                     defaultTemplate: TemplateIdentifier("video.html"),
+                                                                                     inlineTemplate: TemplateIdentifier("video.html")),
+                                                    outputURL: temporaryDirectoryURL)
+            XCTAssertEqual(result.document?.title, "Royal Wave")
+        }
+
+//        // TODO: It shouldn't be necessary to pass the site into the importer.
+//        let file = try defaultSourceDirectory.copy(try bundle.throwingURL(forResource: "IMG_0581", withExtension: "jpeg"),
+//                                                   to: "image.jpeg",
+//                                                   location: .content)
+//        let importer = ImageImporter()
+//        let settings =  ImageImporter.Settings(defaultCategory: "photos",
+//                                               titleFromFilename: false,
+//                                               defaultTemplate: TemplateIdentifier("photo.html"),
+//                                               inlineTemplate: TemplateIdentifier("image.html"))
+//        let result = try await importer.process(site: defaultSourceDirectory.site,
+//                                                file: file,
+//                                                settings: settings,
+//                                                outputURL: defaultSourceDirectory.site.filesURL)
+//        XCTAssertNotNil(result.document)
+//        XCTAssertEqual(result.document?.title, "Hallgrímskirkja Church")
+    }
+
+}


### PR DESCRIPTION
Photos.app on macOS historically only lets you type 'line separator' characters (not new lines) into the caption field, meaning that they weren't parsing correctly. This change updates `Frontmatter` to permit these characters by simply treating them as new lines.

This change also includes a drive-by refactor to simplify what's passed to importers to make them easier to test and, long-term, make them simpler to implement.