### PR TITLE
fix: Initial work to add structured site settings

### DIFF
--- a/Sources/InContextCore/Builder.swift
+++ b/Sources/InContextCore/Builder.swift
@@ -26,7 +26,7 @@ import SwiftSoup
 
 public class Builder {
 
-    static func context(for document: Document, renderTracker: RenderTracker) -> [String: Any] {
+    static func context(for site: Site, document: Document, renderTracker: RenderTracker) -> [String: Any] {
 
         // TODO: Inline the config loaded from the settings file
         // TODO: Consider separating the store and the site metadata.
@@ -34,10 +34,10 @@ public class Builder {
         return [
             "site": [
                 // TODO: Pull this out of the site configuration (and make required configuration type-safe)
-                "title": "Jason Morley",
+                "title": site.title,
+                "url": site.url.absoluteString,
                 "date_format": "MMMM d, yyyy",
                 "date_format_short": "MMMM d",
-                "url": "https://jbmorley.co.uk",
                 "posts": Function { () throws -> [DocumentContext] in
                     return try renderTracker.documentContexts(query: QueryDescription())
                 },
@@ -173,7 +173,7 @@ public class Builder {
         // Render the document using its top-level template.
         // This is tracked using our document-specific `RenderTracker` instance to allow us to track dependencies
         // (queries and templates) and see if they've changed on future incremental builds.
-        let renderTracker = RenderTracker(store: store, renderManager: renderManager)
+        let renderTracker = RenderTracker(site: site, store: store, renderManager: renderManager)
         let content = try renderTracker.render(document)
         let renderStatus = renderTracker.renderStatus(for: document)
         try await store.save(renderStatus: renderStatus, for: document.url)

--- a/Sources/InContextCore/RenderTracker.swift
+++ b/Sources/InContextCore/RenderTracker.swift
@@ -24,13 +24,15 @@ import Foundation
 
 class RenderTracker {
 
+    private let site: Site
     private let store: Store
     private let renderManager: RenderManager
     private var queries = Set<QueryStatus>()
     private var renderers = Set<RendererInstance>()
     private var statuses = Set<TemplateRenderStatus>()
 
-    init(store: Store, renderManager: RenderManager) {
+    init(site: Site, store: Store, renderManager: RenderManager) {
+        self.site = site
         self.store = store
         self.renderManager = renderManager
     }
@@ -64,7 +66,7 @@ class RenderTracker {
 
     func render(_ document: Document, template: TemplateIdentifier? = nil) throws -> String {
         let template = template ?? document.template
-        let context = Builder.context(for: document, renderTracker: self)
+        let context = Builder.context(for: site, document: document, renderTracker: self)
         return try renderManager.render(renderTracker: self, template: template, context: context)
     }
 

--- a/Sources/InContextCore/Settings.swift
+++ b/Sources/InContextCore/Settings.swift
@@ -1,0 +1,33 @@
+// MIT License
+//
+// Copyright (c) 2023 Jason Barrie Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+// Structured site settings.
+// This is currently only used to parse a known-structured part of the site settings, but it should ultimately handle
+// all configuration.
+struct Settings: Codable {
+
+    let title: String
+    let url: URL
+
+}

--- a/Sources/InContextCore/Site.swift
+++ b/Sources/InContextCore/Site.swift
@@ -24,6 +24,7 @@ import Foundation
 import UniformTypeIdentifiers
 
 import Yaml
+import Yams
 
 public struct Site {
 
@@ -34,9 +35,18 @@ public struct Site {
     public let storeURL: URL
     public let filesURL: URL
 
+    let structuredSettings: Settings
     let settings: [AnyHashable: Any]
 
     let handlers: [AnyHandler]
+
+    public var title: String {
+        return structuredSettings.title
+    }
+
+    public var url: URL {
+        return structuredSettings.url
+    }
 
     public init(rootURL: URL) throws {
         self.rootURL = rootURL
@@ -51,6 +61,7 @@ public struct Site {
         guard let settingsString = String(data: settingsData, encoding: .utf8) else {
             throw InContextError.encodingError
         }
+        self.structuredSettings = try YAMLDecoder().decode(Settings.self, from: settingsData)
         self.settings = try (try Yaml.load(settingsString)).dictionary()
 
         guard let buildSteps = settings["build_steps"] as? [[String: Any]],

--- a/Tests/InContextTests/Tests/ImageImporterTests.swift
+++ b/Tests/InContextTests/Tests/ImageImporterTests.swift
@@ -30,8 +30,8 @@ class ImageImporterTests: ContentTestCase {
     func testExtractTitle() async throws {
 
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-config:
-    title: Example
+title: Example
+url: http://example.com
 build_steps:
   - task: process_files
     args:

--- a/Tests/InContextTests/Tests/MarkdownImporterTests.swift
+++ b/Tests/InContextTests/Tests/MarkdownImporterTests.swift
@@ -29,8 +29,8 @@ class MarkdownImporterTests: ContentTestCase {
 
     func testMarkdownTitleOverride() async throws {
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-config:
-    title: Example
+title: Example
+url: http://example.com
 build_steps:
   - task: process_files
     args:
@@ -59,8 +59,8 @@ These are the contents of the file.
 
     func testMarkdownTitleFromFile() async throws {
         _ = try defaultSourceDirectory.add("site.yaml", contents: """
-config:
-    title: Example
+title: Example
+url: http://example.com
 build_steps:
   - task: process_files
     args:


### PR DESCRIPTION
This change exposes the title and url from 'site.yaml' to the renderer.