### PR TITLE
Add strong typing of arguments to ArgumentProvider

### DIFF
--- a/Sources/InContextCore/Renderers/TiltRenderer.swift
+++ b/Sources/InContextCore/Renderers/TiltRenderer.swift
@@ -26,17 +26,17 @@ import CLua
 import Foundation
 
 fileprivate struct LuaStateArgumentProvider: ArgumentProvider {
-    let L: LuaState!
-    func withArguments<Result>(perform: ([Any?]) throws -> Result) throws -> Result {
-        var arguments: [Any?] = []
-        for i in 1 ... L.gettop() {
-            // First arg is the Function userdata itself
-            if i > 1 {
-                arguments.append(L.toany(i))
-            }
-        }
-        return try perform(arguments)
+    let L: LuaState
+
+    func getArgument<T>(_ index: Int) -> T? {
+        // Index is zero based (so + 1) and the first Lua stack index is the Function userdata, so add another +1
+        return L.tovalue(CInt(index + 2))
     }
+
+    func countArguments() -> Int {
+        return Int(L.gettop() - 1)
+    }
+
 }
 
 fileprivate func callFunctionBlock(_ L: LuaState!) -> CInt {

--- a/Sources/InContextCore/Utilities/ArgumentProvider.swift
+++ b/Sources/InContextCore/Utilities/ArgumentProvider.swift
@@ -24,14 +24,20 @@ import Foundation
 
 protocol ArgumentProvider {
 
-    func withArguments<Result>(perform: ([Any?]) throws -> Result) throws -> Result
+    func countArguments() -> Int
+
+    func getArgument<T>(_ index: Int) -> T?
 
 }
 
 extension Array: ArgumentProvider {
 
-    func withArguments<Result>(perform: ([Any?]) throws -> Result) throws -> Result {
-        return try perform(self)
+    func countArguments() -> Int {
+        return self.count
+    }
+
+    func getArgument<T>(_ index: Int) -> T? {
+        return self[index] as? T
     }
 
 }

--- a/Sources/InContextCore/Utilities/Callable.swift
+++ b/Sources/InContextCore/Utilities/Callable.swift
@@ -31,18 +31,16 @@ protocol Callable {
 extension Array: Callable where Element == Callable {
 
     func call(with provider: ArgumentProvider) throws -> Any? {
-        return try provider.withArguments { arguments in
-            for callable in self {
-                do {
-                    return try callable.call(with: arguments)
-                } catch InContextError.incorrectArguments,
-                        InContextError.noMatchingFunction,
-                        InContextError.incorrectType {
-                    continue
-                }
+        for callable in self {
+            do {
+                return try callable.call(with: provider)
+            } catch InContextError.incorrectArguments,
+                    InContextError.noMatchingFunction,
+                    InContextError.incorrectType {
+                continue
             }
-            throw InContextError.noMatchingFunction
         }
+        throw InContextError.noMatchingFunction
     }
 
 }

--- a/Sources/InContextCore/Utilities/Candidates.swift
+++ b/Sources/InContextCore/Utilities/Candidates.swift
@@ -31,18 +31,16 @@ class Candidates: Callable {
     }
 
     func call(with provider: ArgumentProvider) throws -> Any? {
-        return try provider.withArguments { arguments in
-            for callable in self.callables {
-                do {
-                    return try callable.call(with: arguments)
-                } catch InContextError.incorrectArguments,
-                        InContextError.noMatchingFunction,
-                        InContextError.incorrectType {
-                    continue
-                }
+        for callable in self.callables {
+            do {
+                return try callable.call(with: provider)
+            } catch InContextError.incorrectArguments,
+                    InContextError.noMatchingFunction,
+                    InContextError.incorrectType {
+                continue
             }
-            throw InContextError.noMatchingFunction
         }
+        throw InContextError.noMatchingFunction
     }
 
 }


### PR DESCRIPTION
Which allows LuaArgumentProvider to stop guessing the types of strings and tables (using toany() with guessType=true). This also simplifies things a little.