### PR TITLE
fix: Use 'build' as the build directory instead of 'build-swift'

### DIFF
--- a/InContext/InContext.xcodeproj/xcshareddata/xcschemes/InContext.xcscheme
+++ b/InContext/InContext.xcodeproj/xcshareddata/xcschemes/InContext.xcscheme
@@ -53,15 +53,15 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "build"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "version"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--site /Users/jbmorley/Projects/jbmorley.co.uk"
+            argument = "version"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--site /Users/jbmorley/Projects/jbmorley.co.uk"
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/Sources/InContextCore/Site.swift
+++ b/Sources/InContextCore/Site.swift
@@ -52,7 +52,7 @@ public struct Site {
         self.rootURL = rootURL
         self.contentURL = rootURL.appendingPathComponent("content", isDirectory: true)
         self.templatesURL = rootURL.appendingPathComponent("templates", isDirectory: true)
-        self.buildURL = rootURL.appendingPathComponent("build-swift", isDirectory: true)
+        self.buildURL = rootURL.appendingPathComponent("build", isDirectory: true)
         self.storeURL = buildURL.appendingPathComponent("store.sqlite")
         self.filesURL = buildURL.appendingPathComponent("files", isDirectory: true)
 


### PR DESCRIPTION
'build-swift' was always intended to be a temporary thing.